### PR TITLE
wc - add javascript fixtures for recommendation requests table

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -1,0 +1,42 @@
+const recommendationRequestFixtures = {
+  oneRecommendationRequest: {
+    id: 2,
+    requesterEmail: "testRequester1@gmail.com",
+    professorEmail: "testProfessor1@gmail.com",
+    explanation: "This is a test explanation.",
+    dateRequested: "2025-10-30T00:00:00",
+    dateNeeded: "2025-10-31T00:00:00",
+    done: false,
+  },
+  threeRecommendationRequests: [
+    {
+      id: 2,
+      requesterEmail: "testRequester1@gmail.com",
+      professorEmail: "testProfessor1@gmail.com",
+      explanation: "This is a test explanation.",
+      dateRequested: "2025-10-30T00:00:00",
+      dateNeeded: "2025-10-31T00:00:00",
+      done: false,
+    },
+    {
+      id: 3,
+      requesterEmail: "testRequester2@gmail.com",
+      professorEmail: "testProfessor2@gmail.com",
+      explanation: "This is another test explanation.",
+      dateRequested: "2025-10-30T12:34:56",
+      dateNeeded: "2025-10-31T12:34:56",
+      done: true,
+    },
+    {
+      id: 4,
+      requesterEmail: "testRequester3@gmail.com",
+      professorEmail: "testProfessor3@gmail.com",
+      explanation: "This is a third test explanation.",
+      dateRequested: "2025-10-30T23:59:59",
+      dateNeeded: "2025-10-31T23:59:59",
+      done: false,
+    },
+  ],
+};
+
+export { recommendationRequestFixtures };


### PR DESCRIPTION
Closes #27 

Merge after PR #64 (this branch is based on that branch).

In this PR, we add fixtures for the recommendationRequests table in the frontend.

These will be used for tests and storybook entries later on.